### PR TITLE
"Invalid operand" bugfix

### DIFF
--- a/src/cbson-binary.h
+++ b/src/cbson-binary.h
@@ -15,12 +15,11 @@ typedef struct {
   char* data;
 } cbson_binary_t;
 
-int cbson_binary_create(lua_State* L, uint8_t type, const char* binary, unsigned int size);
+cbson_binary_t* cbson_binary_create(lua_State* L, uint8_t type, const char* binary, unsigned int size);
 int cbson_binary_new(lua_State* L);
 cbson_binary_t* check_cbson_binary(lua_State *L, int index);
 
 extern const struct luaL_Reg cbson_binary_meta[];
-
 extern const struct luaL_Reg cbson_binary_methods[];
 
 #endif

--- a/test/test.lua
+++ b/test/test.lua
@@ -164,13 +164,22 @@ TestBSON = {}
         luaunit.assertEquals(tostring(self.data["dec"]), "0.05")
     end
 
-    function TestBSON:test20_Encode_decimal()
+    function TestBSON:test23_Encode_decimal()
         local encoded = self.cbson.encode({foo = "0.05"})
         luaunit.assertNotNil(encoded)
         local decoded = self.cbson.decode(encoded)
         luaunit.assertNotNil(decoded)
         luaunit.assertNotNil(decoded["foo"])
         luaunit.assertTrue(decoded["foo"] == "0.05")
+    end
+
+    function TestBSON:test24_New_binary_empty()
+        local b = self.cbson.binary()
+        luaunit.assertTrue(b:data() == "")
+        local b = self.cbson.binary("")
+        luaunit.assertTrue(b:data() == "")
+        local b = self.cbson.binary("ZGVhZGJlZWY=", 0)
+        luaunit.assertTrue(b:data() == "ZGVhZGJlZWY=")
     end
 
 


### PR DESCRIPTION
- The check_cbson_binary function should not be called in cbson_binary_new. Otherwise, the "Invalid operand" error occurs. Buggy-code: 
```lua
cbson.binary("aaa") -- Invalid operand. Expected 'cbson.binary'
```
- cbson.binary: if new data size equals current size `data` will not reallocated
- cbson.binary: all arguments now is optional