### PR TITLE
Encode lua tables containing bson data

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Decodes binary BSON data to lua table.
 
 Encodes lua table to binary BSON data.
 
+```lua
+local cbson = require "cbson"
+-- Encodes lua table
+local bson_data = cbson.encode({foobar = {bar = "hello", foo = "world"}})
+print(cbson.to_json(bson_data))  -- { "foobar" : { "foo" : "world", "bar" : "hello" } }
+-- Encodes lua table containing bson data
+local bson_data = cbson.encode({foobar = cbson.from_json('{"bar":"hello","foo":"world"}')})
+print(cbson.to_json(bson_data))  -- { "foobar" : { "bar" : "hello", "foo" : "world" } }
+```
+
 #### `<binary>bson_data = cbson.encode_first(<string>first_key, <table>data)`
 
 Encodes lua table to binary BSON data, putting first_key value at start of bson.  

--- a/src/cbson-encode.c
+++ b/src/cbson-encode.c
@@ -109,7 +109,25 @@ void switch_value(lua_State *L, int index, bson_t* bson, int level, const char* 
 
       case LUA_TSTRING:
       {
-        BSON_APPEND_UTF8(bson, key, lua_tostring(L, index));
+        size_t len;
+        const char* data = lua_tolstring(L, index, &len);
+        bson_t* child = bson_new_from_data((const uint8_t*)data, len);
+        if (child)
+        {
+          if (bson_validate(bson, BSON_VALIDATE_UTF8 | BSON_VALIDATE_EMPTY_KEYS, NULL))
+          {
+            BSON_APPEND_DOCUMENT(bson, key, child);
+          }
+          else
+          {
+            BSON_APPEND_UTF8(bson, key, data);
+          }
+          bson_destroy(child);
+        }
+        else
+        {
+          BSON_APPEND_UTF8(bson, key, data);
+        }
         break;
       }
 


### PR DESCRIPTION
This PR allows users to encode lua tables containing bson data. Because we can't guarantee the iteration order of lua table, in some cases (e.g. `cur:sort(...)`) we need to pass the bson data directly instead of lua table.