### PR TITLE
using metatables for arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ local json_string = cbson.to_relaxed_json(bson_data)
 local bson_data = cbson.from_json(json_string)
 ```
 
+### Compatibility with cjson array metatables
+
+`cjson` (and higher) uses metatable for set table (especially empty) as arrays, so this library can use this (or other)
+metatable for encoding and decoding arrays. See [usage array metatables example](test/using_cjson_array_mt.lua)
+
 ### CBSON Functions
 
 #### `<table>decoded = cbson.decode(<binary>bson_data)`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ local bson_data = cbson.from_json(json_string)
 
 ### Compatibility with cjson array metatables
 
-`cjson` (and higher) uses metatable for set table (especially empty) as arrays, so this library can use this (or other)
+`cjson` (2.1.0.5 and higher) uses metatable for set table (especially empty) as arrays, so this library can use this (or other)
 metatable for encoding and decoding arrays. See [usage array metatables example](test/using_cjson_array_mt.lua)
 
 ### CBSON Functions

--- a/src/cbson-decode.c
+++ b/src/cbson-decode.c
@@ -308,7 +308,12 @@ bool cbson_visit_array(const bson_iter_t *iter, const char *key, const bson_t *v
 
   if (bson_iter_init(&iter_new, v_array))
   {
-    lua_newtable(s->L);
+    { // use metatable for arrays
+      lua_newtable(s->L);
+      luaL_getmetatable(s->L, CBSON_ARRAY_MT);
+      lua_setmetatable(s->L, -2);
+    }
+
     cs.depth = s->depth + 1;
     cs.L = s->L;
     bson_iter_visit_all(&iter_new, &cbson_visitors, &cs);

--- a/src/cbson-encode.c
+++ b/src/cbson-encode.c
@@ -29,6 +29,17 @@ static int is_array(lua_State *L, int index)
   double k;
   int cnt = 0;
 
+  // check by metatable at first
+  if (lua_getmetatable(L, index) != 0) {
+    luaL_getmetatable(L, CBSON_ARRAY_MT);
+    bool is_array_mt = lua_equal(L, -1, -2);
+    lua_pop(L, 2);
+
+    if (is_array_mt) {
+      return 1;
+    }
+  }
+
   lua_pushvalue(L, index);
   lua_pushnil(L);
 

--- a/src/cbson-misc.h
+++ b/src/cbson-misc.h
@@ -1,6 +1,7 @@
 #ifndef __CBSON_MINMAX_H__
 #define __CBSON_MINMAX_H__
 
+#include <lauxlib.h>
 #include <lua.h>
 
 #define UNDEFINED_METATABLE "bson-undef metatable"

--- a/src/cbson.c
+++ b/src/cbson.c
@@ -46,9 +46,19 @@
 #endif
 
 
+int cbson_set_array_mt(lua_State *state) {
+  lua_pushstring(state, CBSON_ARRAY_MT);
+  lua_pushvalue(state, -2);
+  lua_rawset(state, LUA_REGISTRYINDEX);
+
+  return 0;
+}
+
+
 int luaopen_cbson(lua_State *L)
 {
   luaL_Reg cbsonlib[] = {
+    { "set_array_mt",     cbson_set_array_mt },
     { "decode",          cbson_decode },
     { "encode",          cbson_encode },
     { "encode_first",    cbson_encode_first },

--- a/src/cbson.h
+++ b/src/cbson.h
@@ -13,6 +13,7 @@
 #define BSON_MAX_RECURSION 100
 #endif
 
+#define CBSON_ARRAY_MT "CBSON_ARRAY_MT"
 
 #define DEFINE_CHECK(name, type) \
 cbson_##type##_t* check_cbson_##type (lua_State *L, int index) \

--- a/test/using_cjson_array_mt.lua
+++ b/test/using_cjson_array_mt.lua
@@ -1,0 +1,37 @@
+local cjson = require("cjson")
+local cbson = require("cbson")
+
+cjson.decode_array_with_array_mt(true)
+cbson.set_array_mt(cjson.array_mt)
+
+local json = [[
+{
+  "test_cases": [
+    {"object": {
+      "some_data": "some_data"
+    }},
+    {"array": [1, 2, 3]},
+    {"empty_obj": {}},
+    {"empty_arr": []}
+  ]
+}
+]]
+
+local function main()
+  local t = cjson.decode(json)
+
+  local control = cjson.encode(t)
+
+  local bson = cbson.encode(t)
+  local out = cbson.decode(bson)
+
+  local check = cjson.encode(out)
+
+  if control ~= check then
+    print(control)
+    print(check)
+    error("array metatable test failed")
+  end
+end
+
+main()


### PR DESCRIPTION
New releases of `cjson` uses metatables as decision of arrays problem. I add small changes in this library for usage this (or some other) metatable for arrays same way