### PR TITLE
add ordered map in cbson

### DIFF
--- a/src/cbson.c
+++ b/src/cbson.c
@@ -46,7 +46,8 @@
 #endif
 
 
-int cbson_set_array_mt(lua_State *state) {
+int cbson_set_array_mt(lua_State *state)
+{
   lua_pushstring(state, CBSON_ARRAY_MT);
   lua_pushvalue(state, -2);
   lua_rawset(state, LUA_REGISTRYINDEX);
@@ -58,7 +59,7 @@ int cbson_set_array_mt(lua_State *state) {
 int luaopen_cbson(lua_State *L)
 {
   luaL_Reg cbsonlib[] = {
-    { "set_array_mt",     cbson_set_array_mt },
+    { "set_array_mt",    cbson_set_array_mt },
     { "decode",          cbson_decode },
     { "encode",          cbson_encode },
     { "encode_first",    cbson_encode_first },
@@ -121,6 +122,13 @@ int luaopen_cbson(lua_State *L)
   lua_setfield(L, -2, "_NAME");
   lua_pushliteral(L, CBSON_VERSION);
   lua_setfield(L, -2, "_VERSION");
+
+  lua_newtable(L); // ordered_map_mt
+  lua_pushstring(L, CBSON_ORDERED_MAP_MT);
+  lua_pushvalue(L, -2);
+  lua_rawset(L, LUA_REGISTRYINDEX);
+
+  lua_setfield(L, -2, "ordered_map_mt");
 
   return 1;
 }

--- a/src/cbson.h
+++ b/src/cbson.h
@@ -14,6 +14,8 @@
 #endif
 
 #define CBSON_ARRAY_MT "CBSON_ARRAY_MT"
+#define CBSON_ORDERED_MAP_MT "CBSON_ORDERED_MAP_MT"
+
 
 #define DEFINE_CHECK(name, type) \
 cbson_##type##_t* check_cbson_##type (lua_State *L, int index) \

--- a/test/using_ordered_map.lua
+++ b/test/using_ordered_map.lua
@@ -1,0 +1,35 @@
+-- XXX problem with luajit interpreter and it's hash funciton: when we create
+-- some map, then pairs in the table can has not same order like we exactly set.
+-- So we need use ordered_map for set order of keys in document exactly like we
+-- want to
+--
+-- Why ordered_map can be needed? So it can be needed for sorting output in mongo.
+-- There uses json documents for sorting and order of keys in the documents have
+-- meaning
+--
+local cbson = require("cbson")
+
+local ordered_map_mt = cbson.ordered_map_mt
+
+local json_sample = '{ "alpha" : "alpha", "bravo" : "bravo" }'
+local json_sample2 = '{ "bravo" : "bravo", "alpha" : "alpha" }'
+
+-- first case
+local data =
+  setmetatable({{alpha = "alpha"}, {bravo = "bravo"}}, ordered_map_mt)
+local out = cbson.encode(data)
+local json = cbson.to_json(out)
+if json ~= json_sample then
+  error(string.format("expected: %s but get %s", json_sample, json))
+end
+
+-- second case
+local data2 = setmetatable({{bravo = "bravo"}, {alpha = "alpha"}},
+                           ordered_map_mt)
+local out2 = cbson.encode(data2)
+local json2 = cbson.to_json(out2)
+if json2 ~= json_sample2 then
+  error(string.format("expected: %s but get %s", json_sample2, json2))
+end
+
+print("ok")


### PR DESCRIPTION
Sometimes it is needed to create bson document with concrete order of fields. As example for using sorting in mongo. But it is impassible with using tables in lua (luajit), because key-values pairs in tables ordered by hash function from key. So if I try to encode lua table like it:

```lua
local t = {alpha = "alpha", bravo = "bravo", charlie = "charlie"}
```

I can get result bson object like:

```
{"charlie": "charlie", "alpha": "alpha", "bravo": "bravo"}
```

So I add new object for serialization: ordered map. It is array of key-values pairs, that has metatable as `cbson.ordered_map_mt`. Here is an [example](test/using_ordered_map.lua) of usage